### PR TITLE
"TypeError" on new tab

### DIFF
--- a/SublimeBlockCursor.py
+++ b/SublimeBlockCursor.py
@@ -19,9 +19,14 @@ class SublimeBlockCursor(sublime_plugin.EventListener):
             view.erase_regions('SublimeBlockCursorListener')
 
     def on_selection_modified(self, view):
-        if view.settings().get('is_widget') or not("Vintage" in view.settings().get('ignored_packages') or view.settings().get('command_mode')):
+        is_widget = view.settings().get('is_widget')
+        is_vintage_mode = "Vintage" not in view.settings().get('ignored_packages', [])
+        command_mode = view.settings().get('command_mode')
+
+        if is_widget or (is_vintage_mode and not command_mode):
             view.erase_regions('SublimeBlockCursorListener')
             return
+
         self.show_block_cursor(view)
 
     def on_deactivated(self, view):


### PR DESCRIPTION
I have noticed that plugin raises **TypeError** on new tab creation.
Looks like there is a brief moment when `view.settings().get('ignored_packages')` is `None`
I made small refactoring and fixed the bug
