### PR TITLE
Add a couple bug fixes to SublimeBlockCursor.py.

### DIFF
--- a/SublimeBlockCursor.py
+++ b/SublimeBlockCursor.py
@@ -3,9 +3,6 @@ import sublime_plugin
 
 
 class SublimeBlockCursor(sublime_plugin.EventListener):
-    def view_is_widget(view):
-        settings = view.settings()
-        return bool(settings.get('is_widget'))
 
     def show_block_cursor(self, view):
         validRegions = []
@@ -19,6 +16,8 @@ class SublimeBlockCursor(sublime_plugin.EventListener):
             view.erase_regions('SublimeBlockCursorListener')
 
     def on_selection_modified(self, view):
+        if view is None:
+            return
         is_vintage_mode = "Vintage" not in view.settings().get('ignored_packages', [])
         command_mode = view.settings().get('command_mode')
 
@@ -40,3 +39,7 @@ class SublimeBlockCursor(sublime_plugin.EventListener):
 
     def on_command_mode_change(self):
         self.on_selection_modified(self.current_view)
+
+def view_is_widget(view):
+    settings = view.settings()
+    return bool(settings.get('is_widget'))


### PR DESCRIPTION
Fixed a `NameError`, as `view_is_widget` was defined as a method, but used like a function. So, moved it out of the class, although a smaller fix would have been to just add `self.` to the `view_is_widget` call, in `on_selection_modified()`.

Also, added a None type check, to suppress some errors I saw in the console. The latter fix is slightly different to, but addresses the same issue reported in PR #13. Only just seen that PR, but I applied the patch a while ago, so I'm not exactly sure under what circumstances that error message is produced...
